### PR TITLE
Fix OAuth callback: Use correct field name 'authenticated'

### DIFF
--- a/frontend/src/components/OAuthCallback.tsx
+++ b/frontend/src/components/OAuthCallback.tsx
@@ -36,7 +36,7 @@ export function OAuthCallback() {
           const response = await fetch('/api/v1/auth/status');
           const data = await response.json();
           
-          if (data.is_authenticated) {
+          if (data.authenticated) {
             // Store token info for display
             sessionStorage.setItem('tokenInfo', JSON.stringify(data));
             sessionStorage.removeItem('oauth_state');


### PR DESCRIPTION
## Summary
- Fixed critical production bug where frontend was checking wrong field name
- Changed from 'is_authenticated' to 'authenticated' to match backend response

## Issue
The production OAuth callback was failing with 'Authentication succeeded but no tokens found' error even though the backend was successfully storing tokens and returning authenticated=true.

## Root Cause
The frontend OAuthCallback component was checking for 'data.is_authenticated' but the backend /api/v1/auth/status endpoint returns 'data.authenticated'.

## Solution
Updated the field name check in OAuthCallback.tsx to use the correct field name.

## Testing
Verified the backend returns:
```json
{
  "authenticated": true,
  "token_valid": true,
  "expires_at": "2025-09-13T20:16:39.928506Z",
  "refresh_count": 0,
  "last_refresh": null,
  "scope": "advertising::campaign_management"
}
```

This is a minimal, critical fix to resolve the production issue immediately.